### PR TITLE
AttrDict deepcopy fails with  KeyError: '__deepcopy__'

### DIFF
--- a/libconf.py
+++ b/libconf.py
@@ -59,10 +59,11 @@ class AttrDict(collections.OrderedDict):
     '''
 
     def __getattr__(self, attr):
-        if attr == '_OrderedDict__root':
-            # Work around Python2's OrderedDict weirdness.
-            raise AttributeError("AttrDict has no attribute %r" % attr)
-        return self.__getitem__(attr)
+        # Work around Python2's OrderedDict weirdness.
+        try:
+            return self.__getitem__(attr)
+        except KeyError:
+            raise AttributeError(attr)
 
 
 class ConfigParseError(RuntimeError):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, flake8
+envlist = py27, py33, py34, py35, flake8
 
 [testenv]
 commands = py.test {posargs} # substitute with tox' positional arguments


### PR DESCRIPTION
  - __getattr__ raises AttributeError and the __getitem__ raises
  KeyError
  - As __getattr__ is redirected to __getitem__ the exception has to be
  raised accordingly
  - This also works for the attribute _OrderedDict__root
  - Deep copy calls getattr(x, "__deepcopy__", None) and fails if
  AttributeError is not raised on unavailable attributes