### PR TITLE
TOX env variable py33 added

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, flake8
+envlist = py27, py33, py34, py35, flake8
 
 [testenv]
 commands = py.test {posargs} # substitute with tox' positional arguments


### PR DESCRIPTION
 - tox ci is failing as py33 env variable was missing