### PR TITLE
Allow empty element in a list

### DIFF
--- a/libconf.py
+++ b/libconf.py
@@ -456,10 +456,9 @@ class Parser:
             if v is None:
                 if first:
                     return []
-                else:
-                    self.tokens.error("expected value after ','")
+            else:
+                values.append(v)
 
-            values.append(v)
             if not self.tokens.accept(','):
                 return values
 


### PR DESCRIPTION
This is broader than the original libconfig specs
https://hyperrealm.github.io/libconfig/libconfig_manual.html#Lists since
it allows empty elements anywhere in the list but it enables the "last
element in a list may be followed by a comma" case.

Fix #18 